### PR TITLE
fix for empty value

### DIFF
--- a/ManyToManyBehavior.php
+++ b/ManyToManyBehavior.php
@@ -120,6 +120,10 @@ class ManyToManyBehavior extends Behavior
 
             $newValue = $this->getNewValue($attributeName);
 
+            $empty_array=[0=>''];
+            if(is_array($newValue) && !array_diff($newValue,$empty_array))
+                continue;
+
             $bindingKeys = $newValue;
 
             // many-to-many


### PR DESCRIPTION
Привет. Обнаружил ситуацию, в которой при отправлении формы с селектом с пустым значением в результате в таблицу связей пытается встать NULL.

Собственно этот патч убирает эту ошибку.